### PR TITLE
Use mddiffcheck. prefix on params

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,14 +31,14 @@ Flags:
 When adding diffs into markdown, use the following format:
 
 - Specify the code block is a diff with `diff` on the same line as the backticks.
-- Specify the base git reference the diff applies to, either a tag or a commit sha, using the `check.base=` parameter.
+- Specify the base git reference the diff applies to, either a tag or a commit sha, using the `mddiffcheck.base=` parameter.
 
 ````
 # Heading
 
 ## Subheading
 
-```diff check.base=v16.0.0
+```diff mddiffcheck.base=v16.0.0
 diff --git a/src/xdr/Stellar-ledger-entries.x b/src/xdr/Stellar-ledger-entries.x
 index 0e7bc842..68c52758 100644
 --- a/src/xdr/Stellar-ledger-entries.x

--- a/main.go
+++ b/main.go
@@ -104,13 +104,13 @@ func checkFile(stderr io.Writer, workingDir, filename string, markdown io.Reader
 			return fmt.Errorf("parsing params %q: %w", params, err)
 		}
 
-		ignore := paramValues.Get("check.ignore")
+		ignore := paramValues.Get("mddiffcheck.ignore")
 		if ignore == "true" {
-			fmt.Fprintf(stderr, "%s:%d: skipping due to check.ignore=true\n", filename, lineNum)
+			fmt.Fprintf(stderr, "%s:%d: skipping due to mddiffcheck.ignore=true\n", filename, lineNum)
 			return nil
 		}
 
-		base := paramValues.Get("check.base")
+		base := paramValues.Get("mddiffcheck.base")
 		if base == "" {
 			return fmt.Errorf("no base specified for diff")
 		}

--- a/testdata/cap-0039-fail.md
+++ b/testdata/cap-0039-fail.md
@@ -61,7 +61,7 @@ accounts for contracts, such as payment channels.
 This patch of XDR changes is based on the XDR files in commit
 `b9e10051eafa1125e8d238a47e5915dad30c2640` of stellar-core.
 
-```diff check.base=b9e10051eafa1125e8d238a47e5915dad30c2640
+```diff mddiffcheck.base=b9e10051eafa1125e8d238a47e5915dad30c2640
 diff --git a/src/xdr/Stellar-ledger-entries.x b/src/xdr/Stellar-ledger-entries.x
 index 0e7bc842..68c52758 100644
 --- a/src/xdr/Stellar-ledger-entries.x

--- a/testdata/cap-0039.md
+++ b/testdata/cap-0039.md
@@ -61,7 +61,7 @@ accounts for contracts, such as payment channels.
 This patch of XDR changes is based on the XDR files in commit
 `b9e10051eafa1125e8d238a47e5915dad30c2640` of stellar-core.
 
-```diff check.base=b9e10051eafa1125e8d238a47e5915dad30c2640
+```diff mddiffcheck.base=b9e10051eafa1125e8d238a47e5915dad30c2640
 diff --git a/src/xdr/Stellar-ledger-entries.x b/src/xdr/Stellar-ledger-entries.x
 index 0e7bc842..68c52758 100644
 --- a/src/xdr/Stellar-ledger-entries.x


### PR DESCRIPTION
### What
Use `mddiffcheck.` prefix on params.

### Why
So that the prefix on params is consistent with the tool name.