### PR TITLE
doc: fix installation guidelines

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,11 +10,11 @@ The tool runs `git` as a subprocess and requires it to be installed.
 ## Usage
 
 ```
-$ go get github.com/stellar/mddiff@latest
+$ go install github.com/stellar/mddiffcheck@latest
 ```
 
 ```
-$ mddiff -help
+$ mddiffcheck -help
 Usage of mddiffcheck:
   mddiffcheck -repo=<repo> <markdown-file> [markdown-file] ...
 


### PR DESCRIPTION
1. the package address is wrong.
2. installing executables with 'go get' in module mode is deprecated.