### PR TITLE
Add support for multiple repositories

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ Flags:
   -help
         print this help
   -repo string
-        repository to verify diffs against
+        repository to verify diffs against, multiple repos specified as space separated
 ```
 
 When adding diffs into markdown, use the following format:

--- a/go.mod
+++ b/go.mod
@@ -1,10 +1,15 @@
 module github.com/stellar/mddiffcheck
 
-go 1.16
+go 1.24
 
 require (
 	4d63.com/testcli v0.0.0-20210109214154-c990b0f8dfb6
-	github.com/davecgh/go-spew v1.1.1 // indirect
 	github.com/stretchr/testify v1.7.0
 	github.com/yuin/goldmark v1.3.7
+)
+
+require (
+	github.com/davecgh/go-spew v1.1.1 // indirect
+	github.com/pmezard/go-difflib v1.0.0 // indirect
+	gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c // indirect
 )

--- a/main_test.go
+++ b/main_test.go
@@ -12,9 +12,16 @@ import (
 func TestCheckSuccess(t *testing.T) {
 	h := testcli.Helper{TB: t}
 
-	markdownPath := filepath.Join("testdata", "cap-0039.md")
+	markdownPath1 := filepath.Join("testdata", "cap-0039.md")
+	markdownPath2 := filepath.Join("testdata", "cap-0070.md")
 
-	args := []string{"mddiffcheck", "-repo", "https://github.com/stellar/stellar-core", markdownPath}
+	args := []string{
+		"mddiffcheck",
+		"-repo",
+		"https://github.com/stellar/stellar-core https://github.com/stellar/stellar-xdr",
+		markdownPath1,
+		markdownPath2,
+	}
 
 	exitCode, stdout, stderr := h.Main(args, nil, run)
 	assert.Equal(t, 0, exitCode)
@@ -26,8 +33,54 @@ func TestCheckSuccess(t *testing.T) {
 repo: ok
 testdata/cap-0039.md:64: parsing diff
 testdata/cap-0039.md:64: checking out base ref b9e10051eafa1125e8d238a47e5915dad30c2640
+testdata/cap-0039.md:64: fetched from https://github.com/stellar/stellar-core
 testdata/cap-0039.md:64: checking diff (/tmp/out)...
 testdata/cap-0039.md:64: ok
+testdata/cap-0070.md:49: parsing diff
+testdata/cap-0070.md:49: checking out base ref 8903b65de5cb56e361800e93aa339ab1a5c1a2e7
+testdata/cap-0070.md:49: fetched from https://github.com/stellar/stellar-xdr
+testdata/cap-0070.md:49: checking diff (/tmp/out)...
+testdata/cap-0070.md:49: ok
+`,
+		stderrSimplified,
+	)
+}
+
+func TestFetchFail(t *testing.T) {
+	h := testcli.Helper{TB: t}
+
+	markdownPath1 := filepath.Join("testdata", "cap-0039.md")
+	markdownPath2 := filepath.Join("testdata", "cap-0070.md")
+
+	args := []string{
+		"mddiffcheck",
+		"-repo",
+		"https://github.com/stellar/stellar-core https://github.com/stellar/rs-stellar-xdr",
+		markdownPath1,
+		markdownPath2,
+	}
+
+	exitCode, stdout, stderr := h.Main(args, nil, run)
+	assert.Equal(t, 1, exitCode)
+	assert.Equal(t, "", stdout)
+	stderrSimplified := regexp.MustCompile(`/(tmp|var)([/_a-zA-Z0-9]*)/\d+`).ReplaceAllLiteralString(stderr, "/tmp/out")
+	assert.Equal(
+		t,
+		`repo: cloning https://github.com/stellar/stellar-core into /tmp/out...
+repo: ok
+testdata/cap-0039.md:64: parsing diff
+testdata/cap-0039.md:64: checking out base ref b9e10051eafa1125e8d238a47e5915dad30c2640
+testdata/cap-0039.md:64: fetched from https://github.com/stellar/stellar-core
+testdata/cap-0039.md:64: checking diff (/tmp/out)...
+testdata/cap-0039.md:64: ok
+testdata/cap-0070.md:49: parsing diff
+testdata/cap-0070.md:49: checking out base ref 8903b65de5cb56e361800e93aa339ab1a5c1a2e7
+testdata/cap-0070.md:49: error: fetching "8903b65de5cb56e361800e93aa339ab1a5c1a2e7":
+fetch 8903b65de5cb56e361800e93aa339ab1a5c1a2e7 from https://github.com/stellar/stellar-core: exit status 128
+fatal: remote error: upload-pack: not our ref 8903b65de5cb56e361800e93aa339ab1a5c1a2e7
+fetch 8903b65de5cb56e361800e93aa339ab1a5c1a2e7 from https://github.com/stellar/rs-stellar-xdr: exit status 128
+fatal: remote error: upload-pack: not our ref 8903b65de5cb56e361800e93aa339ab1a5c1a2e7
+error: one or more diffs failed to apply
 `,
 		stderrSimplified,
 	)
@@ -50,6 +103,7 @@ func TestCheckFail(t *testing.T) {
 repo: ok
 testdata/cap-0039-fail.md:64: parsing diff
 testdata/cap-0039-fail.md:64: checking out base ref b9e10051eafa1125e8d238a47e5915dad30c2640
+testdata/cap-0039-fail.md:64: fetched from https://github.com/stellar/stellar-core
 testdata/cap-0039-fail.md:64: checking diff (/tmp/out)...
 testdata/cap-0039-fail.md:64: error: git apply: applying /tmp/out into /tmp/out: exit status 1
 error: patch failed: src/xdr/Stellar-ledger-entries.x:114
@@ -77,6 +131,7 @@ func TestCheckSuccessWithOrphanCommit(t *testing.T) {
 repo: ok
 testdata/cap-0048.md:79: parsing diff
 testdata/cap-0048.md:79: checking out base ref 7fcc8002a595e59fad2c9bedbcf019865fb6b373
+testdata/cap-0048.md:79: fetched from https://github.com/stellar/stellar-core
 testdata/cap-0048.md:79: checking diff (/tmp/out)...
 testdata/cap-0048.md:79: ok
 `,

--- a/testdata/cap-0070.md
+++ b/testdata/cap-0070.md
@@ -1,0 +1,154 @@
+## Preamble
+
+```
+CAP: 0070
+Title: Configurable SCP Timing Parameters
+Working Group:
+    Owner: Garand Tyson <@SirTyson>
+    Authors: Garand Tyson <@SirTyson>
+    Consulted: Nicolas Barry <@MonsieurNicolas>
+Status: Awaiting Decision
+Created: 2025-04-28
+Discussion: https://github.com/orgs/stellar/discussions/1719
+Protocol version: TBD
+```
+
+## Simple Summary
+
+This CAP introduces ledger configuration settings allowing the Stellar network to dynamically adjust ledger close times, nomination timeouts,
+and ballot timeouts to facilitate controlled, incremental improvements to block time performance.
+
+## Motivation
+
+Currently, Stellar's ledger close time and SCP timeout settings are hardcoded. This restricts the network's ability to gradually test and implement
+shorter block times, limiting improvements in performance and responsiveness. Additionally, as other network parameters such as ledger limits and transaction
+throughput evolve, SCP nomination and ballot phase timings may need to be adjusted to maintain efficiency and resilience.
+
+This CAP addresses these issues by making these parameters configurable, enabling small, incremental adjustments and performance tuning.
+
+## Goals Alignment
+
+The proposal aligns with Stellar’s goals of scalability, resilience, and performance by enabling iterative improvements in ledger close time and consensus efficiency.
+
+## Abstract
+
+We define new network configuration settings for:
+
+- Target ledger close time (milliseconds)
+- Initial nomination timeout (milliseconds)
+- Initial ballot timeout (milliseconds)
+- Per-round nomination timeout increment (milliseconds)
+- Per-round ballot timeout increment (milliseconds)
+
+These settings are introduced as ledger config parameters, allowing the Stellar network to adjust consensus timings incrementally.
+
+## Specification
+
+### XDR Changes
+
+```diff mddiffcheck.base=8903b65de5cb56e361800e93aa339ab1a5c1a2e7
+diff --git a/Stellar-contract-config-setting.x b/Stellar-contract-config-setting.x
+index 30e41ad..5fc19f3 100644
+--- a/Stellar-contract-config-setting.x
++++ b/Stellar-contract-config-setting.x
+@@ -302,6 +302,14 @@ struct EvictionIterator {
+     uint64 bucketFileOffset;
+ };
+ 
++struct ConfigSettingSCPTiming {
++    uint32 ledgerTargetCloseTimeMilliseconds;
++    uint32 nominationTimeoutInitialMilliseconds;
++    uint32 nominationTimeoutIncrementMilliseconds;
++    uint32 ballotTimeoutInitialMilliseconds;
++    uint32 ballotTimeoutIncrementMilliseconds;
++};
++
+ // limits the ContractCostParams size to 20kB
+ const CONTRACT_COST_COUNT_LIMIT = 1024;
+ 
+@@ -325,7 +333,8 @@ enum ConfigSettingID
+     CONFIG_SETTING_LIVE_SOROBAN_STATE_SIZE_WINDOW = 12,
+     CONFIG_SETTING_EVICTION_ITERATOR = 13,
+     CONFIG_SETTING_CONTRACT_PARALLEL_COMPUTE_V0 = 14,
+-    CONFIG_SETTING_CONTRACT_LEDGER_COST_EXT_V0 = 15
++    CONFIG_SETTING_CONTRACT_LEDGER_COST_EXT_V0 = 15,
++    CONFIG_SETTING_SCP_TIMING = 16
+ };
+ 
+ union ConfigSettingEntry switch (ConfigSettingID configSettingID)
+@@ -362,5 +371,7 @@ case CONFIG_SETTING_CONTRACT_PARALLEL_COMPUTE_V0:
+     ConfigSettingContractParallelComputeV0 contractParallelCompute;
+ case CONFIG_SETTING_CONTRACT_LEDGER_COST_EXT_V0:
+     ConfigSettingContractLedgerCostExtV0 contractLedgerCostExt;
++case CONFIG_SETTING_SCP_TIMING:
++    ConfigSettingSCPTiming contractSCPTiming;
+ };
+ }
+```
+
+## Semantics
+
+All initial values will match the current hardcoded values. The initial upgrade to protocol 23 should
+have no actual effect on SCP, but will open the door for future changes.
+
+Note: All ranges are approximate values for sanity checking, but are untested. Actual upgrades should be within
+these ranges, but must still be tested and validated.
+
+- **ledgerTargetCloseTimeMilliseconds**
+    - Target ledger close time in milliseconds. Validators will use this value to set the nextLedgerTrigger timer.
+    - Initial value: 5000
+    - Range: [2000, 5000]
+- **nominationTimeoutInitialMilliseconds**
+    - Initial timeout for SCP nomination phase in milliseconds.
+    - Initial value: 1000
+    - Range: [500, 3000]
+- **nominationTimeoutIncrementMilliseconds**
+    - Incremental timeout increase per additional nomination round in milliseconds.
+    - Initial value: 1000
+    - Range: [0, 2000]
+- **ballotTimeoutInitialMilliseconds**
+    - Initial timeout for SCP ballot phase in milliseconds
+    - Initial value: 1000
+    - Range: [500, 3000]
+- **ballotTimeoutIncrementMilliseconds**
+    - Incremental timeout increase per additional ballot round in milliseconds
+    - Initial value: 1000
+    - Range: [0, 2000]
+For some ballot/nomination round `i`, the timeout for that round is calculated as:
+
+```
+round_timeout(i) = initial_timeout + (i * increment_timeout)
+```
+
+## Design Rationale
+
+Introducing configurable consensus parameters provides essential flexibility, allowing the network to incrementally test and adopt shorter ledger
+close times without large, disruptive protocol updates. While significant changes, such as going from 5 seconds to 2.5 seconds, will require significant
+protocol work, smaller latency gains can be more easily achieved. While the network of Stellar validators may be able to achieve shorter block times,
+downstream systems may assume a consistent 5 second block time or not be performant enough to handle shorter block times. By making gradual changes via
+SLP instead of protocol upgrades, the network can slowly test small changes and adapt over time to faster ledgers.
+
+When changing `ledgerTargetCloseTimeMilliseconds`, corresponding adjustments to smart contract ledger limits must be made proportionally.
+This ensures consistent resource utilization per second, preventing overload and maintaining network stability. For example, if ledger close times decrease by 20%,
+ledger limits must also decrease by approximately 20% to keep resource usage constant. This proportional adjustment is crucial to avoid excessive validator workloads
+or performance degradation as block times decrease.
+
+As block times decrease, or smart contract limits increase, nomination and ballot timeouts may need to be adjusted for optimal performance. Increased performance
+does not necessarily mean that timeouts should be decreased. For example, shortening the nomination timeout can lead to more timeouts if there are slower nodes
+on the network. These additional nomination timeouts cause more bandwidth and CPU load on the network, which can further degrade slow nodes. This results in
+a "snowball" effect, where the network becomes more and more congested and slow nodes fall further and further behind. As TPS increases and transaction set size
+increases, longer nomination timeouts may actually improve network performance and decrease overall block times, as less values are nominated. While longer
+nomination timeouts can increase network latency on average, they can also cause larger latency spikes if certain nodes are offline or slow.
+
+Given these complexities, it is vital that timeout adjustments be incrementally tested and validated through simulation to identify safe and optimal settings.
+Only small, gradual changes should be proposed.
+
+## Test Cases
+
+For the implementation of this CAP, no testing will be required outside of unit tests, as the default values will be identical to the current hardcoded values.
+However, changes to these configs should be thoroughly tested via [supercluster simulation](https://github.com/stellar/supercluster). When it comes to testing
+network timing changes, it is important to test on large topologies that are most similar to the mainnet topology with installed latency to simulate slow nodes.
+This can be achieved via the "SimulatePubnet" and "SimulatePubnetMixedLoad" missions. On an ideal network, where all nodes are fast, it is likely that
+shorter timeouts will improve network performance. However, on a network with slow nodes, shorter timeouts may cause more values to be nominated, resulting
+in more work for all validators on the network and decreased performance. Network performance can be very sensitive to these timing parameters, so it is important
+to propose small, gradual changes that have been thoroughly simulated.


### PR DESCRIPTION
### What
Add support for specifying multiple repositories for diff verification, enabling the tool to fetch from more than one source to find where the diff should be applied.

### Why
Markdown files may contain diffs that reference commits across different repositories. Legacy CAPs have diffs referencing the stellar-core repository, while new CAPs have diffs referencing the stellar-xdr repository.